### PR TITLE
Add support for docker compose V2

### DIFF
--- a/logs
+++ b/logs
@@ -1,0 +1,6 @@
+if [ ! -z $1 ] 
+then
+	docker-compose -f compose-all-services.yml logs "${1}" -f --tail 10
+else
+	docker-compose -f compose-all-services.yml logs -f --tail 10
+fi

--- a/logs-v2
+++ b/logs-v2
@@ -1,0 +1,6 @@
+if [ ! -z $1 ] 
+then
+	docker compose -f compose-all-services.yml logs "${1}" -f --tail 10
+else
+	docker compose -f compose-all-services.yml logs -f --tail 10
+fi

--- a/start-all-v2
+++ b/start-all-v2
@@ -1,0 +1,3 @@
+set -o allexport; source .env; set +o allexport; envsubst < graph-node-configs/config.tmpl > graph-node-configs/config.toml
+
+docker compose -f compose-all-services.yml up -d --build $@

--- a/start-autoagora-v2
+++ b/start-autoagora-v2
@@ -1,0 +1,3 @@
+set -o allexport; source .env; set +o allexport; envsubst < graph-node-configs/config.tmpl > graph-node-configs/config.toml
+
+docker compose -f compose-autoagora.yml up -d --build $@

--- a/start-essential-v2
+++ b/start-essential-v2
@@ -1,0 +1,3 @@
+set -o allexport; source .env; set +o allexport; envsubst < graph-node-configs/config.tmpl > graph-node-configs/config.toml
+
+docker compose -f compose-graphnode.yml -f compose-indexer.yml -f compose-monitoring.yml up -d --build $@

--- a/start-optional-v2
+++ b/start-optional-v2
@@ -1,0 +1,3 @@
+set -o allexport; source .env; set +o allexport; envsubst < graph-node-configs/config.tmpl > graph-node-configs/config.toml
+
+docker compose -f compose-optional.yml up -d --build $@

--- a/stop-all-v2
+++ b/stop-all-v2
@@ -1,0 +1,1 @@
+docker compose -f compose-all-services.yml down $@

--- a/stop-autoagora-v2
+++ b/stop-autoagora-v2
@@ -1,0 +1,1 @@
+docker compose -f compose-autoagora.yml down $@

--- a/stop-essential-v2
+++ b/stop-essential-v2
@@ -1,0 +1,1 @@
+docker compose -f compose-graphnode.yml -f compose-indexer.yml -f compose-monitoring.yml down $@

--- a/stop-optional-v2
+++ b/stop-optional-v2
@@ -1,0 +1,1 @@
+docker compose -f compose-optional.yml down $@


### PR DESCRIPTION
Currently, docker compose start script only supports docker compose version 1, which has been obsoleted for years.

This pull request adds scripts with the suffix "-v2" for supporting docker compose version 2.

Additionally, this pull request also adds logs scripts to provide a convenient way to view logs of containers.

Tested on Docker Compose version v2.12.2