### PR TITLE
Fix for syntax error when running refresh_sizes.sh

### DIFF
--- a/refresh-sizes.sh
+++ b/refresh-sizes.sh
@@ -1,1 +1,1 @@
-set -o allexport; source .env; set +o allexport; docker exec -it postgres psql "-U" ${DB_USER} ${GRAPH_NODE_DB_NAME} "-c" "refresh materialized view info.subgraph_sizes;"
+set -o allexport; source .env; set +o allexport; docker exec -it postgres psql -U ${DB_USER} ${GRAPH_NODE_DB_NAME} -c "refresh materialized view info.subgraph_sizes;"


### PR DESCRIPTION
Change the command syntax to allow running via Cron. The previous syntax generated a FATAL:  role \"-c\" does not exist error.