### PR TITLE
Bump graph node version from 0.29.0 to 0.30.0

### DIFF
--- a/compose-all-services.yml
+++ b/compose-all-services.yml
@@ -285,7 +285,7 @@ services:
 
 
   index-node-0:
-    image: ${GRAPH_NODE_VERSION:-graphprotocol/graph-node:v0.29.0}
+    image: ${GRAPH_NODE_VERSION:-graphprotocol/graph-node:v0.30.0}
     container_name: index-node-0
     depends_on:
       - postgres
@@ -333,7 +333,7 @@ services:
 
 
   query-node-0:
-    image: ${GRAPH_NODE_VERSION:-graphprotocol/graph-node:v0.29.0}
+    image: ${GRAPH_NODE_VERSION:-graphprotocol/graph-node:v0.30.0}
     container_name: query-node-0
     depends_on:
       - postgres

--- a/compose-graphnode.yml
+++ b/compose-graphnode.yml
@@ -25,7 +25,7 @@ services:
 
 
   index-node-0:
-    image: ${GRAPH_NODE_VERSION:-graphprotocol/graph-node:v0.29.0}
+    image: ${GRAPH_NODE_VERSION:-graphprotocol/graph-node:v0.30.0}
     container_name: index-node-0
     depends_on:
       - postgres
@@ -72,7 +72,7 @@ services:
 
 
   query-node-0:
-    image: ${GRAPH_NODE_VERSION:-graphprotocol/graph-node:v0.29.0}
+    image: ${GRAPH_NODE_VERSION:-graphprotocol/graph-node:v0.30.0}
     container_name: query-node-0
     depends_on:
       - postgres


### PR DESCRIPTION
As per the latest version specified in [networks.md](https://github.com/graphprotocol/indexer/blob/main/docs/networks/mainnet.md).