### PR TITLE
Bump indexer stack version from 0.20.11 to 0.20.12

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -8,7 +8,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh &
 ENV PATH="/root/.cargo/bin:$PATH"
 
 WORKDIR /root/
-RUN git clone -b v0.20.11 https://github.com/graphprotocol/indexer /root/.npm-global/lib/node_modules/@graphprotocol/indexer-cli
+RUN git clone -b v0.20.12 https://github.com/graphprotocol/indexer /root/.npm-global/lib/node_modules/@graphprotocol/indexer-cli
 
 WORKDIR /root/.npm-global/lib/node_modules/@graphprotocol/indexer-cli
 RUN yarn --global --frozen-lockfile --non-interactive --production=false

--- a/cli/altDockerfile
+++ b/cli/altDockerfile
@@ -8,7 +8,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh &
 ENV PATH="/root/.cargo/bin:$PATH"
 
 WORKDIR /root/
-RUN git clone -b v0.20.11 https://github.com/graphprotocol/indexer /root/.npm-global/lib/node_modules/@graphprotocol/indexer-cli
+RUN git clone -b v0.20.12 https://github.com/graphprotocol/indexer /root/.npm-global/lib/node_modules/@graphprotocol/indexer-cli
 RUN git clone https://github.com/graphprotocol/graph-cli /root/.npm-global/lib/node_modules/@graphprotocol/graph-cli
 
 WORKDIR /root/.npm-global/lib/node_modules/@graphprotocol/indexer-cli

--- a/cli/oldDockerfile
+++ b/cli/oldDockerfile
@@ -61,7 +61,7 @@ RUN npm install -g yarn
 
 RUN npm install -g nan
 
-RUN npm i -g @graphprotocol/indexer-cli@v0.20.11 --registry https://registry.npmjs.org/ --unsafe-perm=true
+RUN npm i -g @graphprotocol/indexer-cli@v0.20.12 --registry https://registry.npmjs.org/ --unsafe-perm=true
 
 RUN npm i -g @graphprotocol/graph-cli --registry https://registry.npmjs.org/ --unsafe-perm=true
 

--- a/compose-all-services.yml
+++ b/compose-all-services.yml
@@ -67,7 +67,7 @@ services:
 ######################################################################################
 
   indexer-service:
-    image: ${INDEXER_SERVICE_VERSION:-ghcr.io/semiotic-ai/autoagora-indexer-service:v0.1.2-v0.20.11}
+    image: ${INDEXER_SERVICE_VERSION:-ghcr.io/semiotic-ai/autoagora-indexer-service:v0.1.2-v0.20.12}
     container_name: indexer-service
     depends_on:
       - index-node-0
@@ -206,7 +206,7 @@ services:
 ######################################################################################
 
   indexer-agent:
-    image: ${INDEXER_AGENT_VERSION:-ghcr.io/graphprotocol/indexer-agent:v0.20.11}
+    image: ${INDEXER_AGENT_VERSION:-ghcr.io/graphprotocol/indexer-agent:v0.20.12}
     container_name: indexer-agent
     depends_on:
       - index-node-0

--- a/compose-autoagora.yml
+++ b/compose-autoagora.yml
@@ -28,7 +28,7 @@ services:
 ######################################################################################
 
   indexer-service:
-    image: ${INDEXER_SERVICE_VERSION:-ghcr.io/semiotic-ai/autoagora-indexer-service:v0.1.2-v0.20.11}
+    image: ${INDEXER_SERVICE_VERSION:-ghcr.io/semiotic-ai/autoagora-indexer-service:v0.1.2-v0.20.12}
     container_name: indexer-service
     depends_on:
       - postgres2

--- a/compose-indexer.yml
+++ b/compose-indexer.yml
@@ -44,7 +44,7 @@ services:
 ######################################################################################
 
   indexer-service:
-    image: ${INDEXER_SERVICE_VERSION:-ghcr.io/graphprotocol/indexer-service:v0.20.11}
+    image: ${INDEXER_SERVICE_VERSION:-ghcr.io/graphprotocol/indexer-service:v0.20.12}
     container_name: indexer-service
     depends_on:
       - postgres2
@@ -88,7 +88,7 @@ services:
 ######################################################################################
 
   indexer-agent:
-    image: ${INDEXER_AGENT_VERSION:-ghcr.io/graphprotocol/indexer-agent:v0.20.11}
+    image: ${INDEXER_AGENT_VERSION:-ghcr.io/graphprotocol/indexer-agent:v0.20.12}
     container_name: indexer-agent
     depends_on:
       - postgres2


### PR DESCRIPTION
Bump indexer stack version from 0.20.11 to 0.20.12

Nick wrote on discord: `the recommended Indexer stack version is v0.20.12.`
https://discord.com/channels/438038660412342282/1019635469404885132/1082741908167725196