### PR TITLE
Add apparmor as cli requirement

### DIFF
--- a/docs/pre-requisites.md
+++ b/docs/pre-requisites.md
@@ -114,7 +114,7 @@ On a fresh Ubuntu server login via ssh and execute the following commands:
 ```bash
 apt update -y && apt upgrade -y && apt autoremove -y
 
-apt install docker.io docker-compose httpie curl wget git jq nano -y
+apt install docker.io docker-compose httpie curl wget git jq nano apparmor -y
 
 
 ```


### PR DESCRIPTION
Add apparmor as for some reason that is requirement for cli container

Solves docker image build error:
```
Error response from daemon: AppArmor enabled on system but the docker-default profile could not be loaded
```